### PR TITLE
added fax and mobile mapping path

### DIFF
--- a/src/Service/ModelMapper.php
+++ b/src/Service/ModelMapper.php
@@ -40,6 +40,8 @@ class ModelMapper
                 'BankAccount'       => "Content\\Customer\\BankAccount",
                 'Contacts'          => "Content\\Customer\\Contacts",
                     'Phone'         => "Content\\Customer\\Contacts\\Phone",
+                    'Fax'           => "Content\\Customer\\Contacts\\Phone",
+                    'Mobile'         => "Content\\Customer\\Contacts\\Phone",
                 'Addresses'         => "Content\\Customer\\Addresses",
                     'Address'       => "Content\\Customer\\Addresses\\Address",
             'InstallmentCalculation'=> "Content\\InstallmentCalculation",


### PR DESCRIPTION
Hi,
I'm working for DeineTuer GmbH in Leipzig and we're using your RatePay-Modul for Magento 1.9
In the last two days there were multiple payment attemps returning 'Model exception : Model 'Fax' invalid '.
We figured out, the sub model name path mapping for fax and mobile was missing.
The fix has been successfully tested and deployed in our stating and live system.

Kind regards,
Chris