### PR TITLE
Update a switch 'continue' usage to avoid a PHP warning

### DIFF
--- a/src/RequestBuilder.php
+++ b/src/RequestBuilder.php
@@ -473,7 +473,7 @@ class RequestBuilder
                 case "connectionRetries":
                 case "retryDelay":
                 case "gatewayUrl":
-                    continue;
+                    continue 2;
                     break;
                 default:
                     $this->$attribute = null;


### PR DESCRIPTION
that breaks in test/dev mode on magento1 PHP7