### PR TITLE
fix method annotation

### DIFF
--- a/src/Model/Request/SubModel/Content/Customer/Addresses.php
+++ b/src/Model/Request/SubModel/Content/Customer/Addresses.php
@@ -17,8 +17,7 @@ use RatePAY\Model\Request\SubModel\AbstractModel;
 use RatePAY\Model\Request\SubModel\Content\Customer\Addresses\Address;
 
 /**
- * @method $this     addAddress(Address $address)
- * @method Address[] getAddresses()
+ * @method $this addAddress(Address $address)
  */
 class Addresses extends AbstractModel
 {
@@ -47,4 +46,26 @@ class Addresses extends AbstractModel
             'multiple' => true,
         ],
     ];
+
+    /**
+     * @return Address[]
+     */
+    public function getAddresses()
+    {
+        return $this->__get('Address');
+    }
+
+    /**
+     * @return Address
+     */
+    public function getAddress($type)
+    {
+        foreach ($this->getAddresses() as $address) {
+            if (strtolower($address->getType()) === strtolower($type)) {
+                return $address;
+            }
+        }
+
+        return null;
+    }
 }

--- a/src/Model/Request/SubModel/Content/ShoppingBasket/Items.php
+++ b/src/Model/Request/SubModel/Content/ShoppingBasket/Items.php
@@ -17,8 +17,7 @@ use RatePAY\Model\Request\SubModel\AbstractModel;
 use RatePAY\Model\Request\SubModel\Content\ShoppingBasket\Items\Item;
 
 /**
- * @method $this  addItem(Item $item)
- * @method Item[] getItems()
+ * @method $this addItem(Item $item)
  */
 class Items extends AbstractModel
 {
@@ -75,5 +74,10 @@ class Items extends AbstractModel
         }
 
         return true;
+    }
+
+    public function getItems()
+    {
+        return $this->__get('Item');
     }
 }


### PR DESCRIPTION
Hello @eiriarte-mendez 
i found a typo of the function `getAddresses`.
it should be named `getAddress`.

i added the function ´getAddresses´ cause it makes more sense if the caller get more than one address.
Additional i added the function `getAddress` to get a address by the type (BILLING/DELIVERY)

could you also create a release with this fix? We need it in the unit-test in the shopware 6 plugin

Thanks ✌️ 