### PR TITLE
fix: multiple tracking ids: fix missing model mapping

### DIFF
--- a/src/Model/Request/SubModel/Head/External/Tracking.php
+++ b/src/Model/Request/SubModel/Head/External/Tracking.php
@@ -17,7 +17,7 @@ use RatePAY\Model\Request\SubModel\AbstractModel;
 use RatePAY\Model\Request\SubModel\Head\External\Tracking\Id;
 
 /**
- * @method Id addId(Id $id)
+ * @method Tracking addId(Id $id)
  */
 class Tracking extends AbstractModel
 {
@@ -78,7 +78,7 @@ class Tracking extends AbstractModel
      *
      * @return Tracking
      *
-     * @deprecated please use the SubModel "\RatePAY\Model\Request\SubModel\Head\External\Tracking\Id" to set the TrackingId
+     * @deprecated please use the SubModel `\RatePAY\Model\Request\SubModel\Head\External\Tracking\Id` and add it with the method `addId`
      */
     public function setId($id)
     {
@@ -92,7 +92,7 @@ class Tracking extends AbstractModel
      *
      * @return Tracking
      *
-     * @deprecated please use the SubModel "\RatePAY\Model\Request\SubModel\Head\External\Tracking\Id" to set the TrackingId
+     * @deprecated please use the SubModel `\RatePAY\Model\Request\SubModel\Head\External\Tracking\Id` and add it with the method `addId`
      */
     public function setProvider($provider)
     {
@@ -104,5 +104,29 @@ class Tracking extends AbstractModel
         $id->setProvider($provider);
 
         return $this;
+    }
+
+    /**
+     * @return string|null
+     *
+     * @deprecated please use the function `getIds()` to get the tracking-ids
+     */
+    public function getId()
+    {
+        $ids = $this->getIds();
+
+        return isset($ids[0]) ? $ids[0]->getId() : null;
+    }
+
+    /**
+     * @return string|null
+     *
+     * @deprecated please use the function `getIds()` to get the provider information
+     */
+    public function getProvider()
+    {
+        $ids = $this->getIds();
+
+        return isset($ids[0]) ? $ids[0]->getProvider() : null;
     }
 }

--- a/src/Model/Request/SubModel/Head/External/Tracking/Id.php
+++ b/src/Model/Request/SubModel/Head/External/Tracking/Id.php
@@ -16,9 +16,10 @@ namespace RatePAY\Model\Request\SubModel\Head\External\Tracking;
 use RatePAY\Model\Request\SubModel\AbstractModel;
 
 /**
- * @method string getId()
  * @method $this  setProvider(string $provider)
  * @method string getProvider()
+ * @method string getDescription()
+ * @method $this  setDescription(string $description)
  */
 class Id extends AbstractModel
 {
@@ -52,12 +53,29 @@ class Id extends AbstractModel
     ];
 
     /**
+     * @param string|null $id
+     */
+    public function __construct($id = null)
+    {
+        parent::__construct();
+        $id && $this->setId($id);
+    }
+
+    /**
      * @param string $id
      *
      * @return Id
      */
     public function setId($id)
     {
-        return $this->__set('Description', $id);
+        return $this->setDescription($id);
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getId()
+    {
+        return $this->getDescription();
     }
 }

--- a/src/Service/ModelMapper.php
+++ b/src/Service/ModelMapper.php
@@ -35,6 +35,7 @@ class ModelMapper
             'CustomerDevice' => 'Head\\CustomerDevice',
             'External' => 'Head\\External',
                 'Tracking' => 'Head\\External\\Tracking',
+                    'Id' => 'Head\\External\\Tracking\\Id',
             'Meta' => 'Head\\Meta',
                 'Systems' => 'Head\\Meta\\Systems',
                     'System' => 'Head\\Meta\\Systems\\System',

--- a/tests/Unit/Model/Request/SubModel/Head/External/Tracking/IdTest.php
+++ b/tests/Unit/Model/Request/SubModel/Head/External/Tracking/IdTest.php
@@ -1,0 +1,72 @@
+<?php
+/*
+ * RatePAY php-library
+ *
+ * This document contains trade secret data which are the property of
+ * RatePAY GmbH, Berlin, Germany. Information contained herein must not be used,
+ * copied or disclosed in whole or part unless permitted in writing by RatePAY GmbH.
+ * All rights reserved by RatePAY GmbH.
+ *
+ * Copyright (c) 2020 RatePAY GmbH / Berlin / Germany
+ */
+
+namespace RatePAY\Tests\Unit\Model\Request\SubModel\Head\External;
+
+use PHPUnit\Framework\TestCase;
+use RatePAY\Model\Request\SubModel\Head\External\Tracking;
+use RatePAY\Model\Request\SubModel\Head\External\Tracking\Id;
+use RatePAY\ModelBuilder;
+
+/**
+ * @requires PHPUnit 7.5
+ */
+class IdTest extends TestCase
+{
+    public function testSingleTrackingIdFromArray()
+    {
+        $modelBuilder = new ModelBuilder('id');
+        $modelBuilder->setArray([
+            'Description' => 'TEST',
+            'Provider' => 'DHL'
+        ]);
+
+        /** @var Id $id */
+        $id = $modelBuilder->getModel();
+
+        self::assertEquals('TEST', $id->getId());
+        self::assertEquals('TEST', $id->getDescription());
+        self::assertEquals('DHL', $id->getProvider());
+    }
+
+    public function testToArray()
+    {
+        $id = (new Id())->setId('XXX')->setProvider('OOO');
+
+        self::assertEquals([
+            // this is a little bit tricky:
+            // the cdata will be not written on the root-element cause to `toArray`-method got called directly .
+            // if it is called in an parent model, the cdata element got written into the root-element (what is correct)
+            // this is a "bug" in the toArray method of the AbstractModel
+            // so we need to test the function in a separate method: @see `testTrackingToArray`
+            'description' => [
+                'cdata' => 'XXX',
+            ],
+            'attributes' => ['provider' => ['value' => 'OOO']],
+        ], $id->toArray());
+    }
+
+    public function testTrackingToArray()
+    {
+        $tracking = new Tracking();
+        $tracking->addId((new Id())->setId('XXX')->setProvider('OOO'));
+
+        self::assertEquals([
+            'id' => [
+                [
+                    'cdata' => 'XXX',
+                    'attributes' => ['provider' => ['value' => 'OOO']],
+                ]
+            ]
+        ], $tracking->toArray());
+    }
+}

--- a/tests/Unit/Model/Request/SubModel/Head/External/TrackingTest.php
+++ b/tests/Unit/Model/Request/SubModel/Head/External/TrackingTest.php
@@ -1,0 +1,152 @@
+<?php
+/*
+ * RatePAY php-library
+ *
+ * This document contains trade secret data which are the property of
+ * RatePAY GmbH, Berlin, Germany. Information contained herein must not be used,
+ * copied or disclosed in whole or part unless permitted in writing by RatePAY GmbH.
+ * All rights reserved by RatePAY GmbH.
+ *
+ * Copyright (c) 2020 RatePAY GmbH / Berlin / Germany
+ */
+
+namespace RatePAY\Tests\Unit\Model\Request\SubModel\Head\External;
+
+use PHPUnit\Framework\TestCase;
+use RatePAY\Model\Request\SubModel\Head\External\Tracking;
+use RatePAY\Model\Request\SubModel\Head\External\Tracking\Id;
+use RatePAY\ModelBuilder;
+
+/**
+ * @requires PHPUnit 7.5
+ */
+class TrackingTest extends TestCase
+{
+    public function testSingleFromArray()
+    {
+        $modelBuilder = new ModelBuilder('tracking');
+        $modelBuilder->setArray([
+            [
+                'Id' => [
+                    'Description' => 'Test',
+                ],
+            ],
+        ]);
+        /** @var Tracking $tracking */
+        $tracking = $modelBuilder->getModel();
+
+        self::assertCount(1, $tracking->getIds());
+        self::assertInstanceOf(Id::class, $tracking->getIds()[0]);
+    }
+
+    public function testMultipleFromArray()
+    {
+        $modelBuilder = new ModelBuilder('tracking');
+        $modelBuilder->setArray([
+            [
+                'Id' => [
+                    'Description' => 'Test',
+                ],
+            ],
+            [
+                'Id' => [
+                    'Description' => 'Test',
+                ],
+            ],
+        ]);
+        /** @var Tracking $tracking */
+        $tracking = $modelBuilder->getModel();
+
+        self::assertCount(2, $tracking->getIds());
+        self::assertInstanceOf(Id::class, $tracking->getIds()[0]);
+        self::assertInstanceOf(Id::class, $tracking->getIds()[1]);
+    }
+
+    public function testSingleToArray()
+    {
+        $modelBuilder = new ModelBuilder('tracking');
+        $modelBuilder->setArray([
+            [
+                'Id' => [
+                    'Description' => 'Test',
+                ],
+            ],
+        ]);
+        /** @var Tracking $tracking */
+        $tracking = $modelBuilder->getModel();
+
+        self::assertArrayHasKey('id', $tracking->toArray());
+        self::assertIsArray($tracking->toArray()['id']);
+        self::assertCount(1, $tracking->toArray()['id']);
+    }
+
+    public function testSingleModel()
+    {
+        $tracking = new Tracking();
+        $tracking->addId((new Id('XXX'))->setProvider('OOO'));
+
+        self::assertIsArray($tracking->getIds());
+        self::assertCount(1, $tracking->getIds());
+        self::assertInstanceOf(Id::class, $tracking->getIds()[0]);
+
+        // deprecation tests:
+        self::assertEquals($tracking->getId(), $tracking->getIds()[0]->getId());
+        self::assertEquals($tracking->getProvider(), $tracking->getIds()[0]->getProvider());
+    }
+
+    public function testMultipleModel()
+    {
+        $tracking = new Tracking();
+        $tracking->addId((new Id('XXX'))->setProvider('OOO'));
+        $tracking->addId((new Id('III'))->setProvider('UUU'));
+
+        self::assertIsArray($tracking->getIds());
+        self::assertCount(2, $tracking->getIds());
+        self::assertInstanceOf(Id::class, $tracking->getIds()[0]);
+        self::assertInstanceOf(Id::class, $tracking->getIds()[1]);
+    }
+
+    public function testMultipleToArray()
+    {
+        $modelBuilder = new ModelBuilder('tracking');
+        $modelBuilder->setArray([
+            [
+                'Id' => [
+                    'Description' => 'Test-1',
+                ],
+            ],
+            [
+                'Id' => [
+                    'Description' => 'Test-2',
+                ],
+            ],
+        ]);
+
+        /** @var Tracking $tracking */
+        $tracking = $modelBuilder->getModel();
+
+        self::assertArrayHasKey('id', $tracking->toArray());
+        self::assertIsArray($tracking->toArray()['id']);
+        self::assertCount(2, $tracking->toArray()['id']);
+    }
+
+    public function testDepreactedSingleTrackingIdFromArray()
+    {
+        $modelBuilder = new ModelBuilder('tracking');
+        $modelBuilder->setArray([
+            'Id' => [
+                'Description' => 'OOO',
+                'Provider' => 'XXX'
+            ],
+        ]);
+        /** @var Tracking $tracking */
+        $tracking = $modelBuilder->getModel();
+
+        $ids = $tracking->getIds();
+        self::assertCount(1, $ids);
+        self::assertInstanceOf(Id::class, $ids[0]);
+        self::assertEquals('OOO', $ids[0]->getId());
+        self::assertEquals('XXX', $ids[0]->getProvider());
+    }
+
+}

--- a/tests/Unit/Model/Request/SubModel/Head/ExternalTest.php
+++ b/tests/Unit/Model/Request/SubModel/Head/ExternalTest.php
@@ -1,0 +1,46 @@
+<?php
+/*
+ * RatePAY php-library
+ *
+ * This document contains trade secret data which are the property of
+ * RatePAY GmbH, Berlin, Germany. Information contained herein must not be used,
+ * copied or disclosed in whole or part unless permitted in writing by RatePAY GmbH.
+ * All rights reserved by RatePAY GmbH.
+ *
+ * Copyright (c) 2020 RatePAY GmbH / Berlin / Germany
+ */
+
+namespace RatePAY\Tests\Unit\Model\Request\SubModel\Head;
+
+use PHPUnit\Framework\TestCase;
+use RatePAY\Model\Request\SubModel\Head\External;
+use RatePAY\Model\Request\SubModel\Head\External\Tracking;
+use RatePAY\Model\Request\SubModel\Head\External\Tracking\Id;
+
+/**
+ * @requires PHPUnit 7.5
+ */
+class ExternalTest extends TestCase
+{
+    public function testTracking()
+    {
+        $external = new External();
+        $external->setTracking(
+            (new Tracking())->addId((new Id())->setId('TEST'))
+        );
+
+        self::assertArrayHasKey('tracking', $external->toArray());
+        self::assertIsArray($external->toArray()['tracking']);
+    }
+
+    public function testTrackingToArray()
+    {
+        $external = new External();
+        $external->setTracking(
+            (new Tracking())->addId((new Id())->setId('TEST'))
+        );
+
+        self::assertArrayHasKey('tracking', $external->toArray());
+        self::assertIsArray($external->toArray()['tracking']);
+    }
+}


### PR DESCRIPTION
found an issue after adding the feature of multiple tracking ids:

if you use the array-setters of the models, you can not set the ids, cause the model-mapper does not the "Id" class. 

this MR will fix this.