### PR TITLE
RATEPLUG-222: add handling for fatal errors by the gateway

### DIFF
--- a/src/Service/CommunicationService.php
+++ b/src/Service/CommunicationService.php
@@ -92,10 +92,15 @@ class CommunicationService
 
         $errno = curl_errno($ch);
 
+        $statusCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+
         // close connection
         curl_close($ch);
 
-        if ($response === false) {
+        // status codes 3xx and 5xx are not processable by the SDK (we assume that the body will be invalid too)
+        $invalidStatusCode = $statusCode < 200 || ($statusCode >= 300 && ($statusCode < 400 || $statusCode >= 500));
+
+        if ($invalidStatusCode || $response === false) {
             if ($retries > 0) {
                 if ($retryDelay > 0) {
                     // halt time in milliseconds (entered microseconds * 1000)
@@ -107,6 +112,10 @@ class CommunicationService
 
             if ($errno > 0) {
                 throw new CurlException(curl_strerror($errno));
+            }
+
+            if ($invalidStatusCode) {
+                throw new CurlException('There server answered with an invalid status code.');
             }
         }
 

--- a/tests/Unit/Service/CommunicationServiceTest.php
+++ b/tests/Unit/Service/CommunicationServiceTest.php
@@ -74,6 +74,19 @@ namespace RatePAY\Service {
 
         return $messages[$errorCode];
     }
+
+    function curl_getinfo($handle, $optionCode)
+    {
+        if (!should_call_mocked_global_functions()) {
+            return call_user_func_array('\curl_getinfo', func_get_args());
+        }
+
+        if ($optionCode === CURLINFO_HTTP_CODE) {
+            return CommunicationServiceTest::$forceHttpStatus;
+        }
+
+        return null;
+    }
 }
 
 namespace RatePAY\Tests\Unit\Service {
@@ -89,6 +102,7 @@ namespace RatePAY\Tests\Unit\Service {
         public static $curlDataMock = [];
         public static $curlExecutions = 0;
         public static $expectedCurlFailures = 0;
+        public static $forceHttpStatus = 200;
 
         /**
          * This method is called before the first test of this test class is run.
@@ -166,6 +180,18 @@ namespace RatePAY\Tests\Unit\Service {
             $response = $service->send($xml, 0, 0, 6, 1);
 
             $this->assertEquals('cURL Executed!', $response);
+        }
+
+        public function testCurlRequestWillFailWithHttpError500()
+        {
+            self::$forceHttpStatus = 500;
+            $xml = '<?xml version="1.0" encoding="UTF-8"?><note><to>Foo</to></note>';
+
+            $this->expectException(CurlException::class);
+            $this->expectExceptionMessage('There server answered with an invalid status code.');
+
+            $service = new CommunicationService();
+            $service->send($xml, 0, 0, 6, 1);
         }
 
         public static function incrementCurlExcecutions()

--- a/tests/Unit/Service/ValidateGatewayResponseTest.php
+++ b/tests/Unit/Service/ValidateGatewayResponseTest.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * Ratepay PHP-Library
+ *
+ * This document contains trade secret data which are the property of
+ * Ratepay GmbH, Berlin, Germany. Information contained herein must not be used,
+ * copied or disclosed in whole or part unless permitted in writing by Ratepay GmbH.
+ * All rights reserved by Ratepay GmbH.
+ *
+ * Copyright (c) 2022 Ratepay GmbH / Berlin / Germany
+ */
+
+namespace RatePAY\Service;
+
+use PHPUnit\Framework\TestCase;
+use RatePAY\Exception\RequestException;
+
+class ValidateGatewayResponseTest extends TestCase
+{
+
+    /**
+     * @requires PHPUnit 7.5
+     */
+    public function testIfExceptionWillThrownIfUnexpectedXML()
+    {
+        $xml = '<?xml version="1.0" encoding="UTF-8"?><note><to>Foo</to></note>';
+
+        $this->expectException(RequestException::class);
+        $this->expectExceptionMessageMatches('/An error occurred during the processing of the response from the gateway. Error message: (.*)/');
+
+        new ValidateGatewayResponse('PaymentInit', new \SimpleXMLElement($xml));
+    }
+}


### PR DESCRIPTION
after the gateway was down for a longer time, it shows that it is required to add more exception handlings to the SDK. 

With this PR the SDK will throw an error if the response status code (not the status code IN the response) is 3xx or 5xx. 
We could change it to disallow all status expect the status 200, cause your gateway will always return 200, also if the request has been failed. (e.g. Bad parameters)

On the last downtime the server answers with an 5xx code (if i remember correctly) and send HTML to the requester. 
So the SDK throws also an error, that there are methods called on not existing properties or `null` values. This is caused by that the HTML does not contain the expected response with fields like `system-id`.

error message:
```
NOTICE: PHP message: PHP Fatal error:  Uncaught Error: Call to a member function attributes() on null in <path-to-sdk>/src/Model/Response/AbstractResponse.php:91"
```
With this PR the error got caught (on PHP 7+) and a RatepayException will be thrown. So all systems which are using this SDK can catch this error too.