### PR TITLE
M2-97 - Fixed some "Passing null to parameter of type string is depre…

### DIFF
--- a/src/Model/Request/SubModel/AbstractModel.php
+++ b/src/Model/Request/SubModel/AbstractModel.php
@@ -204,7 +204,7 @@ abstract class AbstractModel
                     }
                 } else {
                     if (key_exists('cdata', $fieldSettings)) {                                     // If value should be encapsulated inside CDATA tag
-                        if (function_exists('mb_detect_encoding') && !mb_detect_encoding($fieldSettings['value'], 'UTF-8', true)) { // Check only if php mdstring extension is loaded
+                        if (function_exists('mb_detect_encoding') && is_string($fieldSettings['value']) && !mb_detect_encoding($fieldSettings['value'], 'UTF-8', true)) { // Check only if php mdstring extension is loaded
                             throw new ModelException("Value of '" . $fieldName . "' has to be encoded in UTF-8");
                         }
                     }

--- a/src/Service/SimpleXmlExtended.php
+++ b/src/Service/SimpleXmlExtended.php
@@ -45,6 +45,10 @@ class SimpleXmlExtended extends \SimpleXMLElement
      */
     private function removeSpecialChars($str)
     {
+        if (!is_string($str)) {
+            return '';
+        }
+
         $search = ['–', '´', '‹', '›', '‘', '’', '‚', '“', '”', '„', '‟', '•', '‒', '―', '—', '™', '¼', '½', '¾'];
         $replace = ['-', "'", '<', '>', "'", "'", ',', '"', '"', '"', '"', '-', '-', '-', '-', 'TM', '1/4', '1/2', '3/4'];
 


### PR DESCRIPTION
…cated" problems for PHP 8.1 compatibility

When fixing compatibility for PHP 8.1 for the Ratepay Magento2 module some problems occured when a cdata parameter was filled with a null value. This was no problem before but with PHP 8.1 being very strict this resulted in a PHP warning which Magento2 converts into an exception.

With these changes the behaviour stays the same as before in PHP 8.1.