### PR TITLE
RATESWSX-252: trim leading/trailing whitespaces from model-values

### DIFF
--- a/src/Model/Request/SubModel/AbstractModel.php
+++ b/src/Model/Request/SubModel/AbstractModel.php
@@ -90,6 +90,7 @@ abstract class AbstractModel
      */
     public function commonSetter($field, $arguments)
     {
+        $arguments = $this->cleanValues($arguments);
         if (is_array($arguments) && $arguments[0] !== '') {
             if (property_exists($this, 'settings') && key_exists($field, $this->settings)) { // If it's a setting, save argument into settings
                 // @ToDo: find a better structure
@@ -112,6 +113,17 @@ abstract class AbstractModel
         }
 
         return $this;
+    }
+
+    private function cleanValues($value)
+    {
+        if (is_array($value)) {
+            return array_map([$this, 'cleanValues'], $value);
+        } elseif (is_string($value)) {
+            return trim($value);
+        }
+
+        return $value;
     }
 
     /**

--- a/tests/Mocks/SimpleRequestModel.php
+++ b/tests/Mocks/SimpleRequestModel.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace RatePAY\Tests\Mocks;
+
+use RatePAY\Model\Request\SubModel\AbstractModel;
+
+class SimpleRequestModel extends AbstractModel
+{
+    public $admittedFields = [
+        'FieldDefault' => [
+            'mandatory' => false,
+        ],
+        'FieldRequired' => [
+            'mandatory' => true,
+        ],
+        'FieldMultiple' => [
+            'mandatory' => false,
+            'multiple' => true
+        ]
+    ];
+
+    public function __construct($admittedFields = null)
+    {
+        $this->admittedFields = $admittedFields ?: $this->admittedFields;
+
+        parent::__construct();
+    }
+
+}

--- a/tests/Unit/Model/Request/SubModel/AbstractModelTest.php
+++ b/tests/Unit/Model/Request/SubModel/AbstractModelTest.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace RatePAY\Tests\Unit\Model\Request\SubModel;
+
+use PHPUnit\Framework\TestCase;
+use RatePAY\ModelBuilder;
+use RatePAY\Tests\Mocks\SimpleRequestModel;
+
+class AbstractModelTest extends TestCase
+{
+
+    public function testRemovingWhiteSpaceMethod_set()
+    {
+        $baseString = "       \t\n\r       leading empty\t\r\nspace (%s)       \t\n\r       ";
+        $model = new SimpleRequestModel();
+        $model->__set('FieldDefault', sprintf($baseString, 'FieldDefault'))
+            ->__set('FieldRequired', sprintf($baseString, 'FieldRequired'))
+            ->__set('FieldMultiple', sprintf($baseString, 'FieldMultiple 1'))
+            ->__set('FieldMultiple', sprintf($baseString, 'FieldMultiple 2'));
+
+        $baseCorrectedString = "leading empty\t\r\nspace (%s)";
+        $data = $model->toArray();
+        self::assertEquals($data['field-default']['value'], sprintf($baseCorrectedString, 'FieldDefault'));
+        self::assertEquals($data['field-required']['value'], sprintf($baseCorrectedString, 'FieldRequired'));
+        self::assertEquals($data['field-multiple']['value'][0], sprintf($baseCorrectedString, 'FieldMultiple 1'));
+        self::assertEquals($data['field-multiple']['value'][1], sprintf($baseCorrectedString, 'FieldMultiple 2'));
+    }
+
+    public function testRemovingWhiteSpaceMethodAnnotationMethods()
+    {
+        $baseString = "       \t\n\r       leading empty\t\r\nspace (%s)       \t\n\r       ";
+        $model = new SimpleRequestModel();
+        $model->setFieldDefault(sprintf($baseString, 'FieldDefault'))
+            ->setFieldRequired(sprintf($baseString, 'FieldRequired'))
+            ->setFieldMultiple(sprintf($baseString, 'FieldMultiple 1'))
+            ->addFieldMultiple(sprintf($baseString, 'FieldMultiple 2'));
+
+        $baseCorrectedString = "leading empty\t\r\nspace (%s)";
+        $data = $model->toArray();
+        self::assertEquals($data['field-default']['value'], sprintf($baseCorrectedString, 'FieldDefault'));
+        self::assertEquals($data['field-required']['value'], sprintf($baseCorrectedString, 'FieldRequired'));
+        self::assertEquals($data['field-multiple']['value'][0], sprintf($baseCorrectedString, 'FieldMultiple 1'));
+        self::assertEquals($data['field-multiple']['value'][1], sprintf($baseCorrectedString, 'FieldMultiple 2'));
+    }
+}


### PR DESCRIPTION
this change adds a function, which trim all leading/trailing whitespaces from the models during the setter-method.

this change includes also unit tests