### PR TITLE
RATESWSX-259: instalment: fix calculatio of getAllowedMoth on ConfigurationRequest

### DIFF
--- a/tests/Unit/Model/Response/ConfigurationRequestTest.php
+++ b/tests/Unit/Model/Response/ConfigurationRequestTest.php
@@ -21,6 +21,8 @@ class ConfigurationRequestTest extends TestCase
             'monthAllowed' => [3, 6, 9, 12, 18, 24, 36],
             'rateMinNormal' => 20.0,
             'interestRateDefault' => 13.7,
+            'paymentFirstday' => 2,
+            'serviceCharge' => 0
         ]);
 
         $allowedMonths = $response->getAllowedMonths($amount);


### PR DESCRIPTION
getAllowedMoth has a legacy calculation of the monthly rate, so the results are not correctly on threshold values.
It has been replace with the offline-calculation-request, so it is the same calculation.